### PR TITLE
feat: Initial Terraform setup for AWS core infrastructure and app ser…

### DIFF
--- a/terraform/aws/.gitignore
+++ b/terraform/aws/.gitignore
@@ -1,0 +1,28 @@
+# Local .terraform directories
+.terraform/
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*.backup
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, by default
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually environment specific
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include tfplan files to ignore the plan output of terraform plan
+*.tfplan
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -1,0 +1,627 @@
+# Fetch available AZs in the current region
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+# Ensure we don't try to use more AZs than available or requested
+locals {
+  azs = slice(data.aws_availability_zones.available.names, 0, var.num_availability_zones)
+}
+
+# VPC
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr_block
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name        = "${var.stack_name_prefix}-vpc"
+    Environment = "dev" # Example tag
+  }
+}
+
+# --- Application Secrets ---
+
+# Hasura Admin Secret (auto-generated)
+resource "random_password" "hasura_admin_password" {
+  length  = 32
+  special = false # Typically admin secrets don't need special chars for URLs etc.
+}
+resource "aws_secretsmanager_secret" "hasura_admin_secret" {
+  name        = "${var.stack_name_prefix}-hasura-admin-secret"
+  description = "Admin secret for Hasura GraphQL engine."
+}
+resource "aws_secretsmanager_secret_version" "hasura_admin_secret_version" {
+  secret_id     = aws_secretsmanager_secret.hasura_admin_secret.id
+  secret_string = random_password.hasura_admin_password.result
+}
+
+# API Token Secret (auto-generated)
+resource "random_password" "api_token" {
+  length           = 40 # Longer for API tokens
+  special          = true
+  override_special = "_-" # Common for tokens
+}
+resource "aws_secretsmanager_secret" "api_token_secret" {
+  name        = "${var.stack_name_prefix}-api-token-secret"
+  description = "Generic API Token for internal services."
+}
+resource "aws_secretsmanager_secret_version" "api_token_secret_version" {
+  secret_id     = aws_secretsmanager_secret.api_token_secret.id
+  secret_string = random_password.api_token.result
+}
+
+# OpenAI API Key Secret (Placeholder)
+resource "aws_secretsmanager_secret" "openai_api_key_secret" {
+  name        = "${var.stack_name_prefix}-openai-api-key"
+  description = "Placeholder for OpenAI API Key - MUST BE MANUALLY UPDATED in AWS console."
+}
+resource "aws_secretsmanager_secret_version" "openai_api_key_secret_version" {
+  secret_id     = aws_secretsmanager_secret.openai_api_key_secret.id
+  secret_string = "ENTER_OPENAI_API_KEY_HERE"
+}
+
+# SuperTokens DB Connection String (Placeholder)
+resource "aws_secretsmanager_secret" "supertokens_db_conn_string_secret" {
+  name        = "${var.stack_name_prefix}-supertokens-db-conn-string"
+  description = "Placeholder for SuperTokens DB Connection String - Manually populate: postgresql://USER:PASS@HOST:PORT/DBNAME"
+}
+resource "aws_secretsmanager_secret_version" "supertokens_db_conn_string_secret_version" {
+  secret_id     = aws_secretsmanager_secret.supertokens_db_conn_string_secret.id
+  secret_string = "postgresql://DB_USER:DB_PASS@DB_HOST:DB_PORT/atomicdb" # Example placeholder
+}
+
+# Hasura DB Connection String (Placeholder)
+resource "aws_secretsmanager_secret" "hasura_db_conn_string_secret" {
+  name        = "${var.stack_name_prefix}-hasura-db-conn-string"
+  description = "Placeholder for Hasura DB Connection String - Manually populate: postgres://USER:PASS@HOST:PORT/DBNAME"
+}
+resource "aws_secretsmanager_secret_version" "hasura_db_conn_string_secret_version" {
+  secret_id     = aws_secretsmanager_secret.hasura_db_conn_string_secret.id
+  secret_string = "postgres://DB_USER:DB_PASS@DB_HOST:DB_PORT/atomicdb" # Example placeholder
+}
+
+# Optaplanner DB Connection String (Placeholder)
+resource "aws_secretsmanager_secret" "optaplanner_db_conn_string_secret" {
+  name        = "${var.stack_name_prefix}-optaplanner-db-conn-string"
+  description = "Placeholder for Optaplanner DB Connection String - Manually populate: jdbc:postgresql://HOST:PORT/DBNAME"
+}
+resource "aws_secretsmanager_secret_version" "optaplanner_db_conn_string_secret_version" {
+  secret_id     = aws_secretsmanager_secret.optaplanner_db_conn_string_secret.id
+  secret_string = "jdbc:postgresql://DB_HOST:DB_PORT/atomicdb?user=DB_USER&password=DB_PASSWORD" # Example placeholder
+}
+
+# Hasura JWT Secret (Placeholder)
+resource "aws_secretsmanager_secret" "hasura_jwt_secret" {
+  name        = "${var.stack_name_prefix}-hasura-jwt-secret"
+  description = "Placeholder for Hasura JWT Secret JSON - Manually update with a strong key. Structure: {'type':'HS256','key':'YOUR_KEY','issuer':'supertokens'}"
+}
+resource "aws_secretsmanager_secret_version" "hasura_jwt_secret_version" {
+  secret_id = aws_secretsmanager_secret.hasura_jwt_secret.id
+  secret_string = jsonencode({
+    type   = "HS256",
+    key    = "REPLACE_WITH_A_STRONG_64_CHAR_HEX_SECRET_OR_MIN_32_CHAR_ASCII_WHEN_UPDATING_MANUALLY",
+    issuer = "supertokens"
+  })
+}
+
+# IAM Role for ECS Task Execution
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name = "${var.stack_name_prefix}-ecs-task-execution-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "${var.stack_name_prefix}-ecs-task-execution-role"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# IAM Role for ECS Application Tasks
+resource "aws_iam_role" "ecs_application_task_role" {
+  name = "${var.stack_name_prefix}-ecs-application-task-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "${var.stack_name_prefix}-ecs-application-task-role"
+  }
+}
+
+# Custom IAM Policy for ECS Application Tasks
+resource "aws_iam_policy" "ecs_application_task_policy" {
+  name        = "${var.stack_name_prefix}-ecs-application-task-policy"
+  description = "Policy for ECS application tasks to access AWS resources"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket"
+        ],
+        Effect = "Allow",
+        Resource = [
+          aws_s3_bucket.data_bucket.arn,
+          "${aws_s3_bucket.data_bucket.arn}/*"
+        ]
+      },
+      {
+        Action = ["secretsmanager:GetSecretValue"],
+        Effect = "Allow",
+        Resource = [
+          "arn:aws:secretsmanager:${var.aws_region}:${data.aws_caller_identity.current.account_id}:secret:${var.stack_name_prefix}-*",
+          aws_secretsmanager_secret.db_credentials.arn
+        ]
+      },
+      {
+        Sid    = "OpenSearchAccess",
+        Action = ["es:ESHttp*"],
+        Effect = "Allow",
+        Resource = [
+          "arn:aws:es:${var.aws_region}:${data.aws_caller_identity.current.account_id}:domain/${var.stack_name_prefix}-*/*"
+        ]
+      },
+      {
+        Sid = "MSKAccess",
+        Action = [
+          "kafka-cluster:Connect",
+          "kafka-cluster:DescribeCluster",
+          "kafka-cluster:AlterClusterPolicy",
+          "kafka-cluster:DescribeTopic",
+          "kafka-cluster:ReadData",
+          "kafka-cluster:WriteData",
+          "kafka-cluster:CreateTopic",
+          "kafka-cluster:DeleteTopic",
+          "kafka:GetBootstrapBrokers"
+        ],
+        Effect = "Allow",
+        Resource = [
+          "arn:aws:kafka:${var.aws_region}:${data.aws_caller_identity.current.account_id}:cluster/${var.stack_name_prefix}-*/*",
+          "arn:aws:kafka:${var.aws_region}:${data.aws_caller_identity.current.account_id}:topic/${var.stack_name_prefix}-*/*"
+        ]
+      },
+      {
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams"
+        ],
+        Effect   = "Allow",
+        Resource = ["arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/${var.stack_name_prefix}-*:*"]
+      }
+    ]
+  })
+  tags = {
+    Name = "${var.stack_name_prefix}-ecs-application-task-policy"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_application_task_role_custom_policy" {
+  role       = aws_iam_role.ecs_application_task_role.name
+  policy_arn = aws_iam_policy.ecs_application_task_policy.arn
+}
+
+# ECS Cluster
+resource "aws_ecs_cluster" "main" {
+  name = "${var.stack_name_prefix}-ecs-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "disabled" # Can be "enabled" or "disabled". Disabled for now to keep it simple.
+  }
+
+  tags = {
+    Name        = "${var.stack_name_prefix}-ecs-cluster"
+    Environment = "dev"
+  }
+}
+
+# RDS PostgreSQL Instance
+
+# Generate a random password for the DB master user
+resource "random_password" "db_master_password" {
+  length           = 16
+  special          = true
+  override_special = "_%@" # Specify allowed special characters
+}
+
+# Store the master password in AWS Secrets Manager
+resource "aws_secretsmanager_secret" "db_credentials" {
+  name        = "${var.stack_name_prefix}-rds-master-credentials"
+  description = "Master credentials for RDS instance, managed by Terraform."
+  #recovery_window_in_days = 0 # Set to 0 for immediate deletion without recovery (for dev only)
+  # Default is 30 days.
+}
+
+resource "aws_secretsmanager_secret_version" "db_credentials_version" {
+  secret_id = aws_secretsmanager_secret.db_credentials.id
+  secret_string = jsonencode({
+    username = var.db_master_username,
+    password = random_password.db_master_password.result
+  })
+}
+
+# DB Subnet Group
+resource "aws_db_subnet_group" "default" {
+  name       = "${var.stack_name_prefix}-db-subnet-group"
+  subnet_ids = aws_subnet.private[*].id # Use private subnets
+
+  tags = {
+    Name = "${var.stack_name_prefix}-db-subnet-group"
+  }
+}
+
+# RDS Instance
+resource "aws_db_instance" "main" {
+  identifier        = "${var.stack_name_prefix}-rds-postgres"
+  allocated_storage = var.db_allocated_storage
+  instance_class    = var.db_instance_class
+  engine            = var.db_engine
+  engine_version    = var.db_engine_version_postgres
+  db_name           = var.db_name
+  username          = var.db_master_username
+  password          = random_password.db_master_password.result # Reference the random password
+
+  db_subnet_group_name   = aws_db_subnet_group.default.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+
+  publicly_accessible     = false
+  skip_final_snapshot     = true # For dev only
+  backup_retention_period = var.db_backup_retention_period
+  multi_az                = var.db_multi_az
+
+  # Apply changes immediately (for dev, can cause downtime)
+  # apply_immediately = true
+
+  tags = {
+    Name        = "${var.stack_name_prefix}-rds-instance"
+    Environment = "dev"
+  }
+}
+
+# Public Subnets
+resource "aws_subnet" "public" {
+  count                   = length(local.azs)
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, count.index) # Example: /24 subnets if VPC is /16
+  availability_zone       = local.azs[count.index]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name        = "${var.stack_name_prefix}-public-subnet-${local.azs[count.index]}"
+    Tier        = "Public"
+    Environment = "dev"
+  }
+}
+
+# Private Subnets
+resource "aws_subnet" "private" {
+  count                   = length(local.azs)
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, count.index + length(local.azs)) # Offset CIDR from public
+  availability_zone       = local.azs[count.index]
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name        = "${var.stack_name_prefix}-private-subnet-${local.azs[count.index]}"
+    Tier        = "Private"
+    Environment = "dev"
+  }
+}
+
+# Internet Gateway
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name        = "${var.stack_name_prefix}-igw"
+    Environment = "dev"
+  }
+}
+
+# Public Route Table
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gw.id
+  }
+
+  tags = {
+    Name        = "${var.stack_name_prefix}-public-rt"
+    Environment = "dev"
+  }
+}
+
+# Associate Public Subnets with Public Route Table
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# NAT Gateway(s) and Private Routing (if enabled)
+resource "aws_eip" "nat" {
+  count  = var.enable_nat_gateway ? length(local.azs) : 0
+  domain = "vpc" # Ensures EIP is VPC-scoped (formerly 'vpc = true')
+  tags = {
+    Name = "${var.stack_name_prefix}-nat-eip-${local.azs[count.index]}"
+  }
+}
+
+resource "aws_nat_gateway" "nat" {
+  count         = var.enable_nat_gateway ? length(local.azs) : 0
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id # Place NAT in public subnet
+
+  tags = {
+    Name        = "${var.stack_name_prefix}-nat-gw-${local.azs[count.index]}"
+    Environment = "dev"
+  }
+
+  depends_on = [aws_internet_gateway.gw]
+}
+
+resource "aws_route_table" "private" {
+  count  = var.enable_nat_gateway ? length(local.azs) : 0
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat[count.index].id
+  }
+
+  tags = {
+    Name        = "${var.stack_name_prefix}-private-rt-${local.azs[count.index]}"
+    Environment = "dev"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count = var.enable_nat_gateway ? length(aws_subnet.private) : 0
+  # Ensure we associate the correct private subnet with its corresponding AZ's route table
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}
+
+# Security Group for Application Load Balancer
+resource "aws_security_group" "alb" {
+  name        = "${var.stack_name_prefix}-alb-sg"
+  description = "Security group for the Application Load Balancer"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow HTTP inbound"
+  }
+  ingress {
+    protocol    = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow HTTPS inbound"
+  }
+
+  egress {
+    protocol    = "-1" # All protocols
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound traffic"
+  }
+
+  tags = {
+    Name = "${var.stack_name_prefix}-alb-sg"
+  }
+}
+
+# Security Group for ECS Tasks/Services
+resource "aws_security_group" "ecs_tasks" {
+  name        = "${var.stack_name_prefix}-ecs-tasks-sg"
+  description = "Security group for ECS tasks"
+  vpc_id      = aws_vpc.main.id
+
+  # Ingress rules will be added later by services or ALB connections
+  # For now, allow all outbound for services to reach internet via NAT or other AWS services
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound traffic"
+  }
+
+  tags = {
+    Name = "${var.stack_name_prefix}-ecs-tasks-sg"
+  }
+}
+
+# Security Group for RDS Database Instance
+resource "aws_security_group" "rds" {
+  name        = "${var.stack_name_prefix}-rds-sg"
+  description = "Security group for RDS PostgreSQL instance"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 5432
+    to_port         = 5432
+    security_groups = [aws_security_group.ecs_tasks.id] # Allow from ECS tasks SG
+    description     = "Allow PostgreSQL from ECS tasks"
+  }
+  # Ingress rules will be added later to allow from ecs_tasks_sg on port 5432
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound traffic"
+  }
+
+  tags = {
+    Name = "${var.stack_name_prefix}-rds-sg"
+  }
+}
+
+# Security Group for MSK Cluster Clients (to be associated with MSK's VPC interface)
+resource "aws_security_group" "msk_client" {
+  name        = "${var.stack_name_prefix}-msk-client-sg"
+  description = "Security group for MSK cluster client connectivity"
+  vpc_id      = aws_vpc.main.id
+
+  # Ingress rules will be added later to allow from ecs_tasks_sg on port 9098 (IAM)
+  # Egress rule to allow MSK to respond (though MSK itself manages its outbound)
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound traffic"
+  }
+  tags = {
+    Name = "${var.stack_name_prefix}-msk-client-sg"
+  }
+}
+
+# ECR Repositories
+resource "aws_ecr_repository" "app" {
+  name                 = "atomic-app" # Consistent with CDK and build scripts
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name = "${var.stack_name_prefix}-ecr-app"
+  }
+}
+
+resource "aws_ecr_repository" "functions" {
+  name                 = "atomic-functions"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name = "${var.stack_name_prefix}-ecr-functions"
+  }
+}
+
+resource "aws_ecr_repository" "handshake" {
+  name                 = "atomic-handshake"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name = "${var.stack_name_prefix}-ecr-handshake"
+  }
+}
+
+resource "aws_ecr_repository" "oauth" {
+  name                 = "atomic-oauth"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name = "${var.stack_name_prefix}-ecr-oauth"
+  }
+}
+
+resource "aws_ecr_repository" "optaplanner" {
+  name                 = "atomic-optaplanner"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name = "${var.stack_name_prefix}-ecr-optaplanner"
+  }
+}
+
+# Data source to get current AWS Account ID for bucket naming (if constructing full name)
+data "aws_caller_identity" "current" {}
+
+# S3 Bucket for Application Data
+resource "aws_s3_bucket" "data_bucket" {
+  # Bucket names must be globally unique. Using a prefix and letting AWS generate a unique suffix
+  # is often safer, e.g., bucket_prefix = "${var.stack_name_prefix}-data-"
+  # However, to try and match the CDK naming convention for learning:
+  bucket = "${var.stack_name_prefix}-data-bucket-${data.aws_caller_identity.current.account_id}-${var.aws_region}"
+
+  tags = {
+    Name        = "${var.stack_name_prefix}-data-bucket"
+    Environment = "dev"
+  }
+}
+
+# Enable versioning (optional, but good practice)
+resource "aws_s3_bucket_versioning" "data_bucket_versioning" {
+  bucket = aws_s3_bucket.data_bucket.id
+  versioning_configuration {
+    status = "Disabled" # Can be "Enabled" or "Suspended". Disabled for simplicity.
+  }
+}
+
+# Block all public access
+resource "aws_s3_bucket_public_access_block" "data_bucket_public_access_block" {
+  bucket = aws_s3_bucket.data_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Server-side encryption (SSE-S3)
+resource "aws_s3_bucket_server_side_encryption_configuration" "data_bucket_sse_config" {
+  bucket = aws_s3_bucket.data_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -1,0 +1,158 @@
+output "vpc_id" {
+  description = "The ID of the VPC."
+  value       = aws_vpc.main.id
+}
+
+output "vpc_cidr_block" {
+  description = "The CIDR block of the VPC."
+  value       = aws_vpc.main.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "List of IDs of public subnets."
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "List of IDs of private subnets."
+  value       = aws_subnet.private[*].id
+}
+
+output "availability_zones_used" {
+  description = "List of Availability Zones used for the subnets."
+  value       = local.azs
+}
+
+output "alb_security_group_id" {
+  description = "The ID of the ALB Security Group."
+  value       = aws_security_group.alb.id
+}
+
+output "ecs_tasks_security_group_id" {
+  description = "The ID of the ECS Tasks Security Group."
+  value       = aws_security_group.ecs_tasks.id
+}
+
+output "rds_security_group_id" {
+  description = "The ID of the RDS Security Group."
+  value       = aws_security_group.rds.id
+}
+
+output "msk_client_security_group_id" {
+  description = "The ID of the MSK Client Security Group."
+  value       = aws_security_group.msk_client.id
+}
+
+output "ecr_app_repository_url" {
+  description = "The URL of the ECR repository for the 'app' service."
+  value       = aws_ecr_repository.app.repository_url
+}
+
+output "ecr_functions_repository_url" {
+  description = "The URL of the ECR repository for the 'functions' service."
+  value       = aws_ecr_repository.functions.repository_url
+}
+
+output "ecr_handshake_repository_url" {
+  description = "The URL of the ECR repository for the 'handshake' service."
+  value       = aws_ecr_repository.handshake.repository_url
+}
+
+output "ecr_oauth_repository_url" {
+  description = "The URL of the ECR repository for the 'oauth' service."
+  value       = aws_ecr_repository.oauth.repository_url
+}
+
+output "ecr_optaplanner_repository_url" {
+  description = "The URL of the ECR repository for the 'optaplanner' service."
+  value       = aws_ecr_repository.optaplanner.repository_url
+}
+
+output "s3_data_bucket_id" {
+  description = "The ID (name) of the S3 data bucket."
+  value       = aws_s3_bucket.data_bucket.id
+}
+
+output "s3_data_bucket_arn" {
+  description = "The ARN of the S3 data bucket."
+  value       = aws_s3_bucket.data_bucket.arn
+}
+
+output "s3_data_bucket_domain_name" {
+  description = "The domain name of the S3 data bucket."
+  value       = aws_s3_bucket.data_bucket.bucket_domain_name
+}
+
+output "db_instance_address" {
+  description = "The connection endpoint for the RDS instance."
+  value       = aws_db_instance.main.address
+}
+
+output "db_instance_port" {
+  description = "The connection port for the RDS instance."
+  value       = aws_db_instance.main.port
+}
+
+output "db_instance_name" {
+  description = "The database name."
+  value       = aws_db_instance.main.db_name
+}
+
+output "db_master_username" {
+  description = "The master username for the RDS instance."
+  value       = aws_db_instance.main.username # Or var.db_master_username
+}
+
+output "db_credentials_secret_arn" {
+  description = "The ARN of the AWS Secrets Manager secret holding DB master credentials."
+  value       = aws_secretsmanager_secret.db_credentials.arn
+}
+
+output "ecs_cluster_name" {
+  description = "The name of the ECS cluster."
+  value       = aws_ecs_cluster.main.name
+}
+
+output "ecs_cluster_arn" {
+  description = "The ARN of the ECS cluster."
+  value       = aws_ecs_cluster.main.arn
+}
+
+output "ecs_task_execution_role_arn" {
+  description = "The ARN of the ECS Task Execution Role."
+  value       = aws_iam_role.ecs_task_execution_role.arn
+}
+
+output "ecs_application_task_role_arn" {
+  description = "The ARN of the ECS Application Task Role."
+  value       = aws_iam_role.ecs_application_task_role.arn
+}
+
+output "hasura_admin_secret_arn" {
+  description = "ARN of the Hasura Admin Secret."
+  value       = aws_secretsmanager_secret.hasura_admin_secret.arn
+}
+output "api_token_secret_arn" {
+  description = "ARN of the API Token Secret."
+  value       = aws_secretsmanager_secret.api_token_secret.arn
+}
+output "openai_api_key_secret_arn" {
+  description = "ARN of the OpenAI API Key Secret (Placeholder)."
+  value       = aws_secretsmanager_secret.openai_api_key_secret.arn
+}
+output "supertokens_db_conn_string_secret_arn" {
+  description = "ARN of the SuperTokens DB Connection String Secret (Placeholder)."
+  value       = aws_secretsmanager_secret.supertokens_db_conn_string_secret.arn
+}
+output "hasura_db_conn_string_secret_arn" {
+  description = "ARN of the Hasura DB Connection String Secret (Placeholder)."
+  value       = aws_secretsmanager_secret.hasura_db_conn_string_secret.arn
+}
+output "optaplanner_db_conn_string_secret_arn" {
+  description = "ARN of the Optaplanner DB Connection String Secret (Placeholder)."
+  value       = aws_secretsmanager_secret.optaplanner_db_conn_string_secret.arn
+}
+output "hasura_jwt_secret_arn" {
+  description = "ARN of the Hasura JWT Secret (Placeholder)."
+  value       = aws_secretsmanager_secret.hasura_jwt_secret.arn
+}

--- a/terraform/aws/providers.tf
+++ b/terraform/aws/providers.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+  required_version = ">= 1.0"
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -1,0 +1,82 @@
+variable "aws_region" {
+  description = "The AWS region to deploy resources in."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "stack_name_prefix" {
+  description = "A prefix for naming resources to ensure uniqueness and grouping."
+  type        = string
+  default     = "atomic"
+}
+
+variable "vpc_cidr_block" {
+  description = "The CIDR block for the VPC."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "num_availability_zones" {
+  description = "Number of Availability Zones to use for subnets."
+  type        = number
+  default     = 2
+  validation {
+    condition     = var.num_availability_zones >= 1 && var.num_availability_zones <= 3 # Max 3 for simplicity here
+    error_message = "Number of AZs must be between 1 and 3."
+  }
+}
+
+variable "enable_nat_gateway" {
+  description = "Enable NAT gateway for outbound internet access from private subnets."
+  type        = bool
+  default     = true
+}
+
+variable "db_instance_class" {
+  description = "The instance class for the RDS instance."
+  type        = string
+  default     = "db.t3.micro" # Or db.t4g.micro for Graviton
+}
+
+variable "db_allocated_storage" {
+  description = "The allocated storage for the RDS instance (in GB)."
+  type        = number
+  default     = 20
+}
+
+variable "db_engine" {
+  description = "The database engine for the RDS instance."
+  type        = string
+  default     = "postgres"
+}
+
+variable "db_engine_version_postgres" {
+  description = "The PostgreSQL engine version."
+  type        = string
+  default     = "15.6" # Specify a recent minor version
+}
+
+variable "db_name" {
+  description = "The name of the initial database to create."
+  type        = string
+  default     = "atomicdb"
+}
+
+variable "db_master_username" {
+  description = "The master username for the RDS instance."
+  type        = string
+  default     = "postgresadmin"
+  # Add validation for username if needed (e.g. length, allowed characters)
+}
+
+variable "db_backup_retention_period" {
+  description = "The backup retention period for the RDS instance (in days). 0 to disable automated backups."
+  type        = number
+  default     = 0 # Disabled for dev/cost savings
+}
+
+variable "db_multi_az" {
+  description = "Specifies if the RDS instance is multi-AZ."
+  type        = bool
+  default     = false # For dev/cost savings
+}


### PR DESCRIPTION
…vices

This commit lays the groundwork for deploying your Atomic application stack to AWS using Terraform. It covers Phase 1 and the initial parts of Phase 2 of the Terraform AWS deployment plan.

Key infrastructure and configurations defined:

**Phase 1: Core Infrastructure & Networking**
- Terraform project initialized in `terraform/aws` with AWS and Random providers.
- Core networking: VPC, public/private subnets, Internet Gateway, NAT Gateways, and associated Route Tables.
- Foundational Security Groups for ALB, ECS tasks, RDS, and MSK client connectivity.
- ECR Repositories for all custom services: `atomic-app`, `atomic-functions`, `atomic-handshake`, `atomic-oauth`, `atomic-optaplanner`.
- S3 data bucket with default security configurations (public access blocked, SSE).
- RDS PostgreSQL instance with a DB subnet group, secure master password management via AWS Secrets Manager (auto-generated password).
- ECS Cluster resource.

**Phase 2 (Partial): Core Application Services Setup**
- IAM Roles for ECS:
    - ECS Task Execution Role (using AWS managed `AmazonECSTaskExecutionRolePolicy`).
    - ECS Application Task Role with a custom IAM policy.
- Custom IAM Policy: Grants permissions to the Application Task Role for S3 (data bucket), Secrets Manager (RDS secret and app-specific secrets via wildcard), and placeholder/wildcard permissions for future OpenSearch and MSK integrations.
- Application-Specific Secrets in AWS Secrets Manager:
    - Auto-generated: `HasuraAdminSecret`, `ApiTokenSecret`.
    - Placeholders requiring your manual update: `OpenAiApiKeySecret`, `SupertokensDbConnStringSecret`, `HasuraDbConnStringSecret`, `OptaplannerDbConnStringSecret`, `PlaceholderHasuraJwtSecret`.

All Terraform code has been formatted using `terraform fmt` and validated with `terraform validate`. The next steps will involve defining the Application Load Balancer and the ECS services themselves.