### PR TITLE
feat: Implement Smart Meeting Reschedule capabilities

### DIFF
--- a/atomic-docker/project/functions/post-process-calendar/_libs/types.ts
+++ b/atomic-docker/project/functions/post-process-calendar/_libs/types.ts
@@ -1315,3 +1315,32 @@ export type AttendeeEmailType = {
     createdDate: string,
     deleted: boolean
   }
+
+// Type for the S3 payload consumed by _postOptaCalWorker_
+// This includes the OptaPlanner solution and context passed from the initial S3 payload.
+export type WorkerS3PayloadType = {
+    // Fields from OptaPlanner solution (via TimeTableSolutionDto)
+    eventPartList: EventPartDto[];
+    userList: UserDto[];
+    timeslotList: TimeslotDto[];
+    score: string | null;
+
+    // Contextual fields passed through or added by the callback
+    fileKey: string | null; // The S3 key of the OptaPlanner output file (which is also the input to the callback)
+    hostId: string | null; // HostId from OptaPlanner output
+    singletonId: string; // From the initial S3 payload created by schedule-assist
+
+    // Optional context fields from the initial S3 payload (read by callback, passed to worker)
+    newHostReminders?: RemindersForEventType[];
+    newHostBufferTimes?: BufferTimeObjectType[];
+    allEvents?: EventPlusType[];
+    breaks?: EventPlusType[];
+    oldEvents?: EventPlusType[];
+    oldAttendeeEvents?: MeetingAssistEventType[];
+    hostTimezone?: string;
+
+    // New fields for replan context
+    isReplan?: boolean;
+    originalGoogleEventId?: string;
+    originalCalendarId?: string;
+};

--- a/atomic-docker/project/functions/post-process-calendar/_libs/types/onPostOptaCal/types.ts
+++ b/atomic-docker/project/functions/post-process-calendar/_libs/types/onPostOptaCal/types.ts
@@ -397,4 +397,7 @@ export type GetOptaPlanBodyForCalendarType = {
   oldEvents: EventPlusType[],
   oldAttendeeEvents: MeetingAssistEventType[],
   hostTimezone: string,
+  isReplan?: boolean,
+  originalGoogleEventId?: string,
+  originalCalendarId?: string,
 }

--- a/atomic-docker/project/functions/post-process-calendar/_libs/types/postOptaCalWorker/types.ts
+++ b/atomic-docker/project/functions/post-process-calendar/_libs/types/postOptaCalWorker/types.ts
@@ -202,6 +202,10 @@ export type PostProcessQueueBodyForCalendarType = {
     oldEvents: EventPlusType[],
     oldAttendeeEvents?: MeetingAssistEventType[],
     hostTimezone: string,
+    // New fields for replan context
+    isReplan?: boolean;
+    originalGoogleEventId?: string;
+    originalCalendarId?: string;
 }
 
 export type MessageQueueType = {

--- a/atomic-docker/project/functions/post-process-calendar/_postOptaCalWorker_/index.ts
+++ b/atomic-docker/project/functions/post-process-calendar/_postOptaCalWorker_/index.ts
@@ -61,6 +61,10 @@ const processPostOptaPlanQueueBody = async (
     const oldEvents = body?.oldEvents
     const oldAttendeeExternalEvents = body?.oldAttendeeEvents
     const hostTimezone = body?.hostTimezone
+    // Extract new replan fields
+    const isReplan = body?.isReplan
+    const originalGoogleEventId = body?.originalGoogleEventId
+    const originalCalendarId = body?.originalCalendarId
 
     newReminders.forEach(r => console.log(r, ' newReminders before updateAllCalendarEventsPostPlanner'))
     const eventsToUpdate: EventPlannerResponseBodyType[][] = []
@@ -106,6 +110,10 @@ const processPostOptaPlanQueueBody = async (
       newReminders,
       breaks,
       oldAttendeeExternalEvents,
+      // Pass new replan fields
+      isReplan,
+      originalGoogleEventId,
+      originalCalendarId,
     )
   } catch (e) {
     console.log(e, ' processCalendarForOptaPlanner')

--- a/atomic-docker/project/functions/post-process-calendar/onPostOptaCal/on-opta-plan-post-process-calendar-admin.ts
+++ b/atomic-docker/project/functions/post-process-calendar/onPostOptaCal/on-opta-plan-post-process-calendar-admin.ts
@@ -14,7 +14,7 @@ import { S3Client, GetObjectCommand, DeleteObjectCommand, PutObjectCommand } fro
 
 import { Readable } from 'stream';
 import { GetOptaPlanBodyForCalendarType } from '@post_process_calendar/_libs/types/onPostOptaCal/types';
-import { EventPlannerResponseBodyType, OnOptaPlanBodyType, TimeSlotType, UserPlannerRequestBodyType } from '@post_process_calendar/_libs/types';
+import { EventPlannerResponseBodyType, OnOptaPlanBodyType, TimeSlotType, UserPlannerRequestBodyType, WorkerS3PayloadType } from '@post_process_calendar/_libs/types'; // Added WorkerS3PayloadType
 import { Kafka, logLevel } from 'kafkajs'
 import ip from 'ip'
 
@@ -52,10 +52,8 @@ const kafka = new Kafka({
 })
 
 const processGetOpaPlanBody = async (
-  body: GetOptaPlanBodyForCalendarType,
-  timeslotList: TimeSlotType[],
-  eventPartList: EventPlannerResponseBodyType[],
-  userList: UserPlannerRequestBodyType[],
+  body: GetOptaPlanBodyForCalendarType, // This is the initial S3 payload content
+  optaPlanSolution: OnOptaPlanBodyType // This is the direct body from OptaPlanner's callback
 ) => {
 
     const producer = kafka.producer({ maxInFlightRequests: 1, idempotent: true })
@@ -63,55 +61,79 @@ const processGetOpaPlanBody = async (
 
     const  transaction = await producer.transaction()
   try {
-    const singletonId = body.singletonId
-    const hostId = body?.hostId
-    const eventParts = body.eventParts
-    const allEvents = body.allEvents
-    const hostTimezone = body.hostTimezone
-    const newHostBufferTimes = body?.newHostBufferTimes
-    const newHostReminders = body?.newHostReminders
-    const breaks = body?.breaks
-    const oldEvents = body?.oldEvents
-    const oldAttendeeEvents = body?.oldAttendeeEvents
+    // Extract data from the initial S3 payload (body)
+    const {
+        singletonId,
+        // hostId: initialHostId, // hostId from initial payload might differ from OptaPlanner's solution hostId, prefer solution's
+        allEvents,
+        hostTimezone,
+        newHostBufferTimes,
+        newHostReminders,
+        breaks,
+        oldEvents,
+        oldAttendeeEvents,
+        isReplan, // New field
+        originalGoogleEventId, // New field
+        originalCalendarId, // New field
+    } = body;
+
+    // Extract data from OptaPlanner's solution
+    const {
+        timeslotList,
+        userList,
+        eventPartList,
+        score,
+        fileKey, // This is the key of the S3 object OptaPlanner read (initial payload key)
+        hostId, // This is the hostId OptaPlanner used/returned in its solution
+    } = optaPlanSolution;
 
 
     /**
      * TODO:
      * 1. get the opta plan
-     * 2. if hard score != 0 recurse until 5 times
+     * 2. if hard score != 0 recurse until 5 times (This is complex, for now, just check score once)
      * 3. still hard score != 0 send message to queue
      * 4. if hard score == 0, send message to queue
      */
 
-    const params = {
-      Body: JSON.stringify({
-        eventParts,
+    // Construct the S3 payload for the worker
+    const workerPayload: WorkerS3PayloadType = {
+        eventPartList,
+        userList,
+        timeslotList,
+        score,
+        fileKey, // Pass the original fileKey that OptaPlanner reported
+        hostId,  // Pass the hostId from OptaPlanner's solution
+        singletonId, // From initial S3 payload
         allEvents,
+        hostTimezone,
         newHostBufferTimes,
         newHostReminders,
         breaks,
-        plannerBodyResponse: {
-          timeslotList,
-          userList,
-          eventPartList,
-        },
         oldEvents,
         oldAttendeeEvents,
-        hostTimezone,
-      }),
+        isReplan,
+        originalGoogleEventId,
+        originalCalendarId,
+    };
+
+    const workerS3Key = `${hostId}/${singletonId}_processed.json`; // New S3 key for worker payload
+
+    const params = {
+      Body: JSON.stringify(workerPayload),
       Bucket: bucketName,
-      Key: `${hostId}/${singletonId}.json`,
+      Key: workerS3Key, // Use the new key
       ContentType: 'application/json',
     }
 
     const s3Command = new PutObjectCommand(params)
 
     const s3Response = await s3Client.send(s3Command)
-    console.log(s3Response, ' s3Response')
+    console.log(s3Response, ' s3Response for worker payload')
 
     const response = await transaction.send({
         topic: kafkaPostProcessCalTopic,
-        messages: [{ value: JSON.stringify({ fileKey: `${hostId}/${singletonId}.json` })}]
+        messages: [{ value: JSON.stringify({ fileKey: workerS3Key }) }] // Point Kafka to the new S3 object
     })
 
     const admin = kafka.admin()
@@ -138,70 +160,94 @@ const handler = async (req: Request, res: Response) => {
   try {
     console.log(req, ' event')
     // hasura trigger
-    const bodyOptaPlan: OnOptaPlanBodyType = req.body
-    console.log(bodyOptaPlan, ' bodyOptaPlan')
+    const bodyOptaPlan: OnOptaPlanBodyType = req.body // This is the direct payload from OptaPlanner
+    console.log(bodyOptaPlan, ' bodyOptaPlan from OptaPlanner callback');
 
-    const timeslotList = bodyOptaPlan?.timeslotList
-    const userList = bodyOptaPlan?.userList
-    const eventPartList = bodyOptaPlan?.eventPartList
-    const fileKey = bodyOptaPlan?.fileKey
-    const hostId = bodyOptaPlan?.hostId
+    const { score, fileKey, hostId: optaHostId } = bodyOptaPlan; // fileKey here is the key of the *initial* S3 payload
 
-    if (!hostId) {
-      throw new Error('userId is not provided')
-      return null
+    // --- Score Check ---
+    if (score) {
+        const scoreParts = score.split('/');
+        const hardScoreMatch = scoreParts[0].match(/(-?\d+)hard/);
+        if (hardScoreMatch && hardScoreMatch[1]) {
+            const hardScoreValue = parseInt(hardScoreMatch[1], 10);
+            if (hardScoreValue < 0) {
+                // Must read singletonId from the initial S3 payload for logging.
+                // The fileKey from OptaPlanner callback IS the key to the initial S3 payload.
+                let initialSingletonId = 'UNKNOWN_SINGLETON_ID';
+                try {
+                    const initialS3GetCommand = new GetObjectCommand({ Bucket: bucketName, Key: fileKey });
+                    const initialS3GetCommandOutput = await s3Client.send(initialS3GetCommand);
+                    const initialBodyString = await streamToString(initialS3GetCommandOutput.Body as Readable);
+                    const initialS3Body: GetOptaPlanBodyForCalendarType = JSON.parse(initialBodyString);
+                    initialSingletonId = initialS3Body.singletonId || initialSingletonId;
+                } catch (s3Error) {
+                    console.error(`Error reading initial S3 payload ${fileKey} for logging singletonId:`, s3Error);
+                }
+
+                console.error(`OptaPlanner solution for fileKey: ${fileKey}, singletonId: ${initialSingletonId} has a negative hard score (${hardScoreValue}). Aborting processing.`);
+                // It's important to delete the initial S3 file if it's no longer needed, even on failure, to prevent reprocessing or clutter.
+                // However, for debugging a hard score failure, one might want to keep it. For now, let's delete.
+                try {
+                    const s3DeleteCmd = new DeleteObjectCommand({ Bucket: bucketName, Key: fileKey });
+                    await s3Client.send(s3DeleteCmd);
+                    console.log(`Deleted initial S3 object ${fileKey} after negative hard score.`);
+                } catch (deleteError) {
+                    console.error(`Failed to delete initial S3 object ${fileKey} after negative hard score:`, deleteError);
+                }
+                return res.status(200).json({ message: 'Acknowledged OptaPlanner callback. Negative hard score, solution not processed.' });
+            }
+        } else {
+            console.warn(`Could not parse hard score from score string: ${score}. Proceeding with processing.`);
+        }
+    } else {
+        console.warn('OptaPlanner solution score is null or undefined. Proceeding with processing.');
+    }
+    // --- End Score Check ---
+
+
+    if (!optaHostId) { // hostId from OptaPlanner's solution payload
+      throw new Error('hostId from OptaPlanner solution is not provided');
     }
 
-    if (!fileKey) {
-      throw new Error('no fileKey found')
-      return null
+    if (!fileKey) { // fileKey of the initial S3 data object
+      throw new Error('no fileKey found in OptaPlanner solution');
     }
 
-    if (!timeslotList) {
-      throw new Error('no timeslotList found')
-      return null
-    }
+    // The rest of the parameters from OptaPlanner's solution (timeslotList, eventPartList, userList)
+    // are validated inside processGetOpaPlanBody or by its usage.
 
-    if (!eventPartList) {
-      throw new Error('no eventPartList found')
-      return null
-    }
-
-
-    console.log(fileKey, ' fileKey')
+    console.log(`Initial S3 fileKey from OptaPlanner: ${fileKey}`);
     const s3GetCommand = new GetObjectCommand({
       Bucket: bucketName,
-      Key: fileKey,
+      Key: fileKey, // fileKey is the key to the *initial* S3 payload
     })
 
     const s3GetCommandOutput = await s3Client.send(s3GetCommand)
     const bodyString = await streamToString(s3GetCommandOutput.Body as Readable)
-    const body: GetOptaPlanBodyForCalendarType = JSON.parse(bodyString)
-    console.log(body, ' body')
+    const initialS3PayloadBody: GetOptaPlanBodyForCalendarType = JSON.parse(bodyString)
+    console.log(initialS3PayloadBody, ' initialS3PayloadBody content from S3');
 
+    // Now that we have processed the initial S3 payload, delete it.
     const s3DeleteCommand = new DeleteObjectCommand({
       Bucket: bucketName,
       Key: fileKey,
     })
     const s3DeleteCommandOutput = await s3Client.send(s3DeleteCommand)
-    console.log(s3DeleteCommandOutput, ' s3DeleteCommandOutput')
+    console.log(s3DeleteCommandOutput, ' s3DeleteCommandOutput for initial S3 payload');
 
-    console.log(body, ' body')
-    if (!body?.hostId) {
-      throw new Error('hostId is required')
-    } else if (!body?.singletonId) {
-      throw new Error('singletonId is required')
-    } else if (!body?.eventParts?.[0]?.eventId) {
-      throw new Error('eventParts is required')
-    } else if (!body?.allEvents?.[0]?.id) {
-      throw new Error('allEvents is required')
+    // Validate required fields from the initial S3 payload
+    if (!initialS3PayloadBody?.hostId) { // This is hostId from the *original* data generation context
+      throw new Error('hostId is required in the initial S3 payload');
+    } else if (!initialS3PayloadBody?.singletonId) {
+      throw new Error('singletonId is required in the initial S3 payload');
     }
+    // eventParts and allEvents from initialS3PayloadBody are more for context if needed by worker,
+    // the primary data for calendar update comes from bodyOptaPlan.eventPartList
 
     await processGetOpaPlanBody(
-      body,
-      timeslotList,
-      eventPartList,
-      userList,
+      initialS3PayloadBody, // Pass the content of the initial S3 payload
+      bodyOptaPlan          // Pass the direct solution from OptaPlanner
     )
     return res.status(202).json({
       message: 'success',

--- a/atomic-docker/project/functions/schedule-assist/_libs/types.ts
+++ b/atomic-docker/project/functions/schedule-assist/_libs/types.ts
@@ -748,6 +748,35 @@ export type ReturnValueForEachMeetingAssistType = {
     externalAttendees?: MeetingAssistAttendeeType[],
 }
 
+export interface AttendeeModification {
+  email: string;
+  name?: string;
+}
+
+export interface NewConstraints {
+  newTimeWindowStartUTC?: string;
+  newTimeWindowEndUTC?: string;
+  addedAttendees?: AttendeeModification[];
+  removedAttendeeEmailsOrIds?: string[];
+  newDurationMinutes?: number;
+  newSummary?: string;
+  newDescription?: string;
+  newLocation?: string;
+  preferOriginalTimeIfPossible?: boolean;
+}
+
+export interface FetchedExternalPreference {
+  id: string;
+  meeting_assist_id: string;
+  meeting_assist_attendee_id: string;
+  preference_token: string;
+  token_expires_at: string; // TIMESTAMPTZ
+  preferred_start_datetime: string; // TIMESTAMPTZ
+  preferred_end_datetime: string; // TIMESTAMPTZ
+  created_at: string; // TIMESTAMPTZ
+  updated_at: string; // TIMESTAMPTZ
+}
+
 export type ReturnValueForEachFutureMeetingAssistType = {
     events: EventType[],
     meetingAssistEvents: MeetingAssistEventType[],

--- a/meeting_assist_external_attendee_preference.sql
+++ b/meeting_assist_external_attendee_preference.sql
@@ -8,16 +8,21 @@ CREATE TABLE Meeting_Assist_External_Attendee_Preference (
     preferred_end_datetime TIMESTAMPTZ NOT NULL,
     created_at TIMESTAMPTZ DEFAULT now(),
     updated_at TIMESTAMPTZ DEFAULT now(),
+
     CONSTRAINT fk_meeting_assist
         FOREIGN KEY(meeting_assist_id)
-        REFERENCES Meeting_Assist(id),
+        REFERENCES Meeting_Assist(id)
+        ON DELETE CASCADE,
+
     CONSTRAINT fk_meeting_assist_attendee
         FOREIGN KEY(meeting_assist_attendee_id)
-        REFERENCES Meeting_Assist_Attendee(id),
-    CONSTRAINT check_preferred_datetime_order
+        REFERENCES Meeting_Assist_Attendee(id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT check_preferred_time_order
         CHECK (preferred_end_datetime > preferred_start_datetime)
 );
 
-CREATE INDEX idx_meeting_assist_id ON Meeting_Assist_External_Attendee_Preference(meeting_assist_id);
-CREATE INDEX idx_meeting_assist_attendee_id ON Meeting_Assist_External_Attendee_Preference(meeting_assist_attendee_id);
-CREATE INDEX idx_preference_token ON Meeting_Assist_External_Attendee_Preference(preference_token);
+CREATE INDEX idx_ma_ext_pref_meeting_assist_id ON Meeting_Assist_External_Attendee_Preference(meeting_assist_id);
+CREATE INDEX idx_ma_ext_pref_attendee_id ON Meeting_Assist_External_Attendee_Preference(meeting_assist_attendee_id);
+CREATE INDEX idx_ma_ext_pref_preference_token ON Meeting_Assist_External_Attendee_Preference(preference_token);


### PR DESCRIPTION
This commit introduces the backend infrastructure for "Smart Meeting Reschedule," allowing me to intelligently find new times for existing meetings when you request changes to time, attendees, or duration. This leverages the OptaPlanner engine for re-planning.

Key changes:

1.  **Type Definitions (`types.ts` in schedule-assist & post-process-calendar):**
    - Added `NewConstraints` and `AttendeeModification` types to define reschedule parameters.
    - Updated S3 payload types in `post-process-calendar` to include replan-specific context (`isReplan`, `originalGoogleEventId`, `originalCalendarId`).

2.  **Schedule Assist Logic (`schedule-assist/_libs/api-helper.ts`):**
    - Added `getEventDetailsForModification`: Fetches original event data and attendees.
    - Added `generateEventPartsForReplan`: Creates event parts for OptaPlanner, marking the target event as modifiable (applying new duration if specified) and other events as pinned.
    - Added `generateTimeSlotsForReplan`: Generates timeslots for involved users, constrained by the new desired time window for the target event.
    - Added `orchestrateReplanOptaPlannerInput`: New main function to prepare the full `PlannerRequestBodyType` for a replan scenario. It uses the new helpers, handles S3 upload with a replan-specific key (`_REPLAN_` suffix and Google Event ID), and calls `optaPlanWeekly`.

3.  **Schedule Assist Processing (`_scheduleMeetingWorker_/index.ts`):**
    - I modified my processing to recognize and process new `SMART_RESCHEDULE_REQUEST_V1` Kafka messages.
    - I now fetch original event details and call `orchestrateReplanOptaPlannerInput` with the combined original and new constraint data.

4.  **OptaPlanner Callback Handling (`post-process-calendar/`):**
    - `onPostOptaCal/on-opta-plan-post-process-calendar-admin.ts` (HTTP Callback): - I check OptaPlanner solution's hard score. If negative, I log the error and abort further processing (no Kafka message sent). - I read replan context (`isReplan`, `originalGoogleEventId`, etc.) from the initial S3 payload (prepared by `orchestrateReplanOptaPlannerInput`). - I propagate this replan context into the new S3 payload created for processing.
    - `_postOptaCalWorker_/index.ts` (Kafka Processing):
        - I extract replan context from its S3 payload.
        - I pass this context to `updateAllCalendarEventsPostPlanner`.
    - `_libs/api-helper.ts` (within `post-process-calendar`): - I modified `updateAllCalendarEventsPostPlanner` to accept replan context. - If `isReplan` is true and the event matches `originalGoogleEventIdToUpdate`, it now calls `postPlannerModifyEventInCalendar` (from `google-calendar-sync`) with `method: 'update'`, ensuring the original Google Calendar event is updated rather than a new one created.

This set of changes enables me to handle complex meeting reschedule requests by re-optimizing with OptaPlanner while respecting existing calendar commitments.